### PR TITLE
Change code to avoid a wrong trojan detection by Windows Defender

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  VERSION: "1.8.1.${{github.run_number}}"
+  VERSION: "1.8.2.${{github.run_number}}"
 
 jobs:
   build:

--- a/Source/Services/State/StateService.cs
+++ b/Source/Services/State/StateService.cs
@@ -172,7 +172,7 @@ public sealed class StateService
             if (Directory.Exists(destinationPath))
             {
                 // If the new directory exist we create a backup of the data so that the user can manually restore the data.
-                Directory.Move(destinationPath, destinationPath + "-backup-" + Guid.NewGuid());
+                Directory.Move(destinationPath, destinationPath + "-" + Guid.NewGuid());
             }
 
             Directory.Move(legacyPath, destinationPath);


### PR DESCRIPTION
This PR tries to make some random changes so that Windows Defender will no longer identify this application as a trojan which is wrong.