### PR TITLE
Fix sorting issue when using filter in inflight data grid

### DIFF
--- a/Source/Pages/Inflight/InflightPageViewModel.cs
+++ b/Source/Pages/Inflight/InflightPageViewModel.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Threading;
 using DynamicData;
+using DynamicData.Binding;
 using mqttMultimeter.Common;
 using mqttMultimeter.Controls;
 using mqttMultimeter.Pages.Inflight.Export;
@@ -39,7 +40,12 @@ public sealed class InflightPageViewModel : BasePageViewModel
 
         var filter = this.WhenAnyValue(x => x.FilterText).Throttle(TimeSpan.FromMilliseconds(800)).Select(BuildFilter);
 
-        _itemsSource.Connect().Filter(filter).ObserveOn(RxApp.MainThreadScheduler).Bind(out _items).Subscribe();
+        _itemsSource.Connect()
+            .Filter(filter)
+            .Sort(SortExpressionComparer<InflightPageItemViewModel>.Ascending(t => t.Number))
+            .ObserveOn(RxApp.MainThreadScheduler)
+            .Bind(out _items)
+            .Subscribe();
     }
 
     public event Action<InflightPageItemViewModel>? RepeatMessageRequested;

--- a/Source/Pages/PacketInspector/PacketInspectorPageViewModel.cs
+++ b/Source/Pages/PacketInspector/PacketInspectorPageViewModel.cs
@@ -92,7 +92,7 @@ public sealed class PacketInspectorPageViewModel : BasePageViewModel
         {
             return Task.CompletedTask;
         }
-        
+
         Dispatcher.UIThread.Invoke(() =>
         {
             var number = _number++;

--- a/Source/mqttMultimeter.sln.DotSettings
+++ b/Source/mqttMultimeter.sln.DotSettings
@@ -235,6 +235,7 @@
     &lt;/Entry&gt;&#xD;
   &lt;/TypePattern&gt;&#xD;
 &lt;/Patterns&gt;</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/Naming/CSharpNaming/ApplyAutoDetectedRules/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
This PR sets a hard coded sorting operation so that filtering will no longer alter the order.