### PR TITLE
Convert the publish item view to be a content presenter within the publish page view (take II)

### DIFF
--- a/Source/Pages/Publish/PublishPageView.axaml
+++ b/Source/Pages/Publish/PublishPageView.axaml
@@ -55,9 +55,9 @@
                           Width="2" />
 
             <!-- The selected item. -->
-            <publish:PublishItemView Margin="10"
+            <ContentPresenter Margin="10"
                                      Grid.Column="2"
-                                     DataContext="{Binding ElementName=PART_Items, Path=SelectedItem}" />
+                                     Content="{Binding ElementName=PART_Items, Path=SelectedItem}" />
         </Grid>
 
     </controls:Overlay>


### PR DESCRIPTION
This PR brings the publish page binding of its PART_Items element inline with the connections and subscriptions pages by making the contained item view be the content of a content presenter